### PR TITLE
fix the build issues due to open bugs by google

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,9 +31,11 @@ jobs:
           command: |
             git clone https://github.com/googleapis/google-cloud-go.git .
             git checkout tags/v0.100.2
-            # enable generation for gads which has a hardcoded value to skip by renaming the skip string
+            echo "replacing hardcoded gads bypass string"
             grep -rl 'google.golang.org/genproto/googleapis/ads' ./internal/gapicgen/generator |
             xargs sed --in-place=backup 's,google.golang.org/genproto/googleapis/ads,google.golang.org/genproto/googleapis/ads_disabled,g'
+            echo "fixing golang protoc arm filename conflict https://groups.google.com/g/adwords-api/c/Tti9vvDPdK4/m/6a86kM18AAAJ"
+            find . -name '*_arm.proto' -exec sh -c 'mv "$0" "${0%_arm.proto}_arm0.proto"' {} \;
       - run:
           name: "Build genbot binary"
           working_directory: "/tmp/src/cloud.google.com/go/internal/gapicgen/cmd"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
           description: "Google like to break things, so ensure that google-cloud-go is up to date, but still working"
           command: |
             git clone https://github.com/googleapis/google-cloud-go.git .
+            echo "temporary fix to checkout a bugfix branch instead of a tag"
             git checkout logging-service-yaml
             echo "replacing hardcoded gads bypass string"
             grep -rl 'google.golang.org/genproto/googleapis/ads' ./internal/gapicgen/generator |
@@ -74,17 +75,6 @@ jobs:
             zip -r /tmp/artifacts/artifacts.zip /tmp/update-genproto/genproto/*
       - store_artifacts:
           path: /tmp/artifacts
-      - run:
-          name: "Publish Release for googleapis on GitHub"
-          command: |
-            go get github.com/tcnksm/ghr
-
-            ghr -t ${GITHUB_TOKEN} \
-              -u ${CIRCLE_PROJECT_USERNAME} \
-              -r ${CIRCLE_PROJECT_REPONAME} \
-              -c ${CIRCLE_SHA1} \
-              -delete ${CIRCLE_TAG} \
-              /tmp/artifacts/artifacts.zip
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           description: "Google like to break things, so ensure that google-cloud-go is up to date, but still working"
           command: |
             git clone https://github.com/googleapis/google-cloud-go.git .
-            git checkout tags/v0.100.0
+            git checkout logging-service-yaml
             echo "replacing hardcoded gads bypass string"
             grep -rl 'google.golang.org/genproto/googleapis/ads' ./internal/gapicgen/generator |
             xargs sed --in-place=backup 's,google.golang.org/genproto/googleapis/ads,google.golang.org/genproto/googleapis/ads_disabled,g'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           description: "Google like to break things, so ensure that google-cloud-go is up to date, but still working"
           command: |
             git clone https://github.com/googleapis/google-cloud-go.git .
-            git checkout tags/v0.100.2
+            git checkout tags/v0.100.1
             echo "replacing hardcoded gads bypass string"
             grep -rl 'google.golang.org/genproto/googleapis/ads' ./internal/gapicgen/generator |
             xargs sed --in-place=backup 's,google.golang.org/genproto/googleapis/ads,google.golang.org/genproto/googleapis/ads_disabled,g'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,6 @@ jobs:
             echo "replacing hardcoded gads bypass string"
             grep -rl 'google.golang.org/genproto/googleapis/ads' ./internal/gapicgen/generator |
             xargs sed --in-place=backup 's,google.golang.org/genproto/googleapis/ads,google.golang.org/genproto/googleapis/ads_disabled,g'
-            echo "fixing golang protoc arm filename conflict https://groups.google.com/g/adwords-api/c/Tti9vvDPdK4/m/6a86kM18AAAJ"
-            find . -name '*_arm.proto' -exec sh -c 'mv "$0" "${0%_arm.proto}_arm0.proto"' {} \;
       - run:
           name: "Build genbot binary"
           working_directory: "/tmp/src/cloud.google.com/go/internal/gapicgen/cmd"
@@ -43,6 +41,12 @@ jobs:
             mkdir -p /tmp/run
             go build -o /tmp/src/genbot cloud.google.com/go/internal/gapicgen/cmd/genbot
       - checkout
+      - run:
+          name: "Fixing filenames"
+          working_directory: "/tmp/src/googleapis"
+          description: "fixing golang _arm.proto filename conflicts https://groups.google.com/g/adwords-api/c/Tti9vvDPdK4/m/6a86kM18AAAJ"
+          command: |
+            find . -name '*_arm.proto' -exec sh -c 'mv "$0" "${0%_arm.proto}_arm0.proto"' {} \;
       - run:
           name: "Build package"
           working_directory: "/tmp/run"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           description: "Google like to break things, so ensure that google-cloud-go is up to date, but still working"
           command: |
             git clone https://github.com/googleapis/google-cloud-go.git .
-            git checkout tags/v0.100.1
+            git checkout tags/v0.100.0
             echo "replacing hardcoded gads bypass string"
             grep -rl 'google.golang.org/genproto/googleapis/ads' ./internal/gapicgen/generator |
             xargs sed --in-place=backup 's,google.golang.org/genproto/googleapis/ads,google.golang.org/genproto/googleapis/ads_disabled,g'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           description: "Google like to break things, so ensure that google-cloud-go is up to date, but still working"
           command: |
             git clone https://github.com/googleapis/google-cloud-go.git .
-            echo "temporary fix to checkout a bugfix branch instead of a tag"
+            echo "temporary fix to checkout a bugfix branch instead of a tag. issue: https://github.com/googleapis/google-cloud-go/pull/5674"
             git checkout logging-service-yaml
             echo "replacing hardcoded gads bypass string"
             grep -rl 'google.golang.org/genproto/googleapis/ads' ./internal/gapicgen/generator |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,8 @@ jobs:
           working_directory: "/tmp/src/googleapis"
           description: "fixing golang _arm.proto filename conflicts https://groups.google.com/g/adwords-api/c/Tti9vvDPdK4/m/6a86kM18AAAJ"
           command: |
-            find . -name '*_arm.proto' -exec sh -c 'mv "$0" "${0%_arm.proto}_arm0.proto"' {} \;
+            cd google
+            find . -name '*_arm.proto' -exec sh -c 'mv "$0" "${0%_arm.proto}_arm0.proto" && grep -rl "$(basename $0)" . | xargs sed --in-place=backup "s,_arm.proto,_arm0.proto,g"' {} \;
       - run:
           name: "Build package"
           working_directory: "/tmp/run"

--- a/.gitallowed
+++ b/.gitallowed
@@ -1,0 +1,2 @@
+# this is a forked repo from Google, disable Credible
+.*

--- a/SEMATIC_README.md
+++ b/SEMATIC_README.md
@@ -1,3 +1,3 @@
 ❗ See https://redventures.atlassian.net/wiki/spaces/SEMATIC/pages/99340551006/Upgrade+Gads+Version for update process.
 
-Other than this `SEMATIC_README.md` file, a `.circleci/.config.yml` file has been added to this repo to automate the build process.
+Only this `SEMATIC_README.md` file, the `.gitallowed` file, and a `.circleci/.config.yml` file have been added to this repo.

--- a/SEMATIC_README.md
+++ b/SEMATIC_README.md
@@ -1,3 +1,3 @@
 ❗ See https://redventures.atlassian.net/wiki/spaces/SEMATIC/pages/99340551006/Upgrade+Gads+Version for update process.
 
-Only this `SEMATIC_README.md` file, the `.gitallowed` file, and a `.circleci/.config.yml` file have been added to this repo.
+Only this `SEMATIC_README.md` file, the `.gitallowed` file, and a `.circleci/.config.yml` file have been added to this repo by RV.


### PR DESCRIPTION
* Fix golang filename assumption by renaming `_arm.proto` files to `_arm0.proto` https://groups.google.com/g/adwords-api/c/Tti9vvDPdK4/m/6a86kM18AAAJ (googleapis/googleapis does not have an issue tracker).
* Fix build issue https://github.com/googleapis/google-cloud-go/pull/5674 by using google's `logging-service-yaml` bugfix branch for `googleapis/google-cloud-go`.
* Remove artifact upload step since it is based on user tokens and currently broken.

Hopefully, the bugfixes will be merged in by the next release https://github.com/googleapis/google-cloud-go/pull/5682